### PR TITLE
Specify source and test dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - pypy
+
+install:
+  - pip install tox tox-travis
+  - pip install coverage coveralls
+
+script:
+  - tox -r

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-cov-core==1.7
-coverage==3.7
-execnet==1.1
-py==1.4.17
-pytest==2.4.2
-pytest-cov==1.6
-pytest-xdist==1.9
+cov-core==1.15.0
+coverage==4.4.1
+execnet==1.4.1
+py==1.4.34
+pytest==3.1.3
+pytest-cov==2.5.1
+pytest-xdist==1.18.0
 tox==2.7.0
 virtualenv==15.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ py==1.4.17
 pytest==2.4.2
 pytest-cov==1.6
 pytest-xdist==1.9
+tox==2.7.0
+virtualenv==15.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,6 @@ license-file = LICENSE
 [wheel]
 universal = 1
 
-[pytest]
-addopts = -rsxX -v
+[tool:pytest]
+addopts = -rsxX -v tests acme
 norecursedirs = .git

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
 
 setup(
     name='skeleton_for_pytest',
-    version='0.0.1',
+    version='0.0.2',
     url='https://github.com/tddbc/python_pytest.git',
     author='TDD BaseCamp',
     author_email='tddbc@googlegroups.com',
@@ -36,6 +36,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+skipsdist = True
+envlist =
+    py27,
+    py33,
+    py34,
+    py35
+
+[testenv]
+deps=
+    -r{toxinidir}/requirements.txt
+commands=
+  python setup.py test


### PR DESCRIPTION
本プロジェクト上にvirtualenvの環境を作ったところ、そのvirtualenv上に保存されている各種ライブラリのテストも動いてしまい、結果としてテストに失敗してしまいました。

この悲しみをほかの人にも味わってほしくないため、py.testの実行時に `tests`と`acme`フォルダを指定してテスト実行するようにしました。

また、Python 3.5では動かないケースもあったようなので(Travis CI調べ)、ライブラリを最新バージョンにしています。

[Travis CIのテスト結果はこちら](https://travis-ci.org/todoa2c/python_pytest/builds/250307496)